### PR TITLE
Refactor notionBlockToMarkdown function

### DIFF
--- a/src/transformers/notion-block-to-markdown.js
+++ b/src/transformers/notion-block-to-markdown.js
@@ -1,153 +1,139 @@
 const { blockToString } = require("../block-to-string")
 
 const EOL_MD = "\n"
+const DOUBLE_EOL_MD = EOL_MD.repeat(2)
 
-exports.notionBlockToMarkdown = (block, lowerTitleLevel, depth = 0) =>
-	block.children.reduce((acc, childBlock) => {
-		let childBlocksString = ""
+// Inserts the string at the beginning of every line of the content. If the useSpaces flag is set to
+// true, the lines after the first will instead be prepended with two spaces.
+function prependToLines(content, string, useSpaces = true) {
+	let [head, ...tail] = content.split("\n")
 
-		if (childBlock.has_children) {
-			childBlocksString = "  "
-				.repeat(depth)
-				.concat(childBlocksString)
-				.concat(this.notionBlockToMarkdown(childBlock, lowerTitleLevel, depth + 2))
-				.concat(EOL_MD)
-		}
+	return [
+		`${string} ${head}`,
+		...tail.map((line) => {
+			return `${useSpaces ? " " : string} ${line}`
+		}),
+	].join("\n")
+}
 
-		if (childBlock.type == "paragraph") {
-			const p = blockToString(childBlock.paragraph.text)
+// Converts a notion block to a markdown string.
+exports.notionBlockToMarkdown = (block, lowerTitleLevel) => {
+	// Get the child content of the block.
+	let childMarkdown = (block.children ?? [])
+		.map((block) => this.notionBlockToMarkdown(block, lowerTitleLevel))
+		.join("")
+		.trim()
 
-			const isTableRow = p.startsWith("|") && p.endsWith("|")
+	// If the block is a page, return the child content.
+	if (block.object === "page") {
+		return childMarkdown
+	}
 
-			return acc
-				.concat(p)
-				.concat(isTableRow ? EOL_MD : EOL_MD.concat(EOL_MD))
-				.concat(childBlocksString)
-		}
+	// Extract the remaining content of the block and combine it with its children.
+	let blockMarkdown = block[block.type]?.text ? blockToString(block[block.type]?.text).trim() : null
+	let markdown = [blockMarkdown, childMarkdown].filter((text) => text).join(DOUBLE_EOL_MD)
 
-		if (childBlock.type.startsWith("heading_")) {
-			const headingLevel = Number(childBlock.type.split("_")[1])
+	// Table row
+	// TODO: This should be moved to the new Notion type.
+	if (block.type == "paragraph" && blockMarkdown.startsWith("|") && blockMarkdown.endsWith("|")) {
+		return markdown.concat(EOL_MD)
+	}
 
-			return acc
-				.concat(EOL_MD)
-				.concat(lowerTitleLevel ? "#" : "")
-				.concat("#".repeat(headingLevel))
-				.concat(" ")
-				.concat(blockToString(childBlock[childBlock.type].text))
-				.concat(EOL_MD)
-				.concat(childBlocksString)
-		}
+	// Paragraph
+	if (block.type == "paragraph") {
+		return [EOL_MD, markdown, EOL_MD].join("")
+	}
 
-		if (childBlock.type == "to_do") {
-			return acc
-				.concat(`- [${childBlock.to_do.checked ? "x" : " "}] `)
-				.concat(blockToString(childBlock.to_do.text))
-				.concat(EOL_MD)
-				.concat(childBlocksString)
-		}
+	// Heading
+	if (block.type.startsWith("heading_")) {
+		const headingLevel = Number(block.type.split("_")[1])
+		let symbol = (lowerTitleLevel ? "#" : "") + "#".repeat(headingLevel)
+		return [EOL_MD, prependToLines(markdown, symbol), EOL_MD].join("")
+	}
 
-		if (childBlock.type == "bulleted_list_item") {
-			return acc
-				.concat("* ")
-				.concat(blockToString(childBlock.bulleted_list_item.text))
-				.concat(EOL_MD)
-				.concat(childBlocksString)
-		}
+	// To do list item
+	if (block.type == "to_do") {
+		let symbol = `- [${block.to_do.checked ? "x" : " "}] `
+		return prependToLines(markdown, symbol).concat(EOL_MD)
+	}
 
-		if (childBlock.type == "numbered_list_item") {
-			return acc
-				.concat("1. ")
-				.concat(blockToString(childBlock.numbered_list_item.text))
-				.concat(EOL_MD)
-				.concat(childBlocksString)
-		}
+	// Bulleted list item
+	if (block.type == "bulleted_list_item") {
+		return prependToLines(markdown, "*").concat(EOL_MD)
+	}
 
-		if (childBlock.type == "toggle") {
-			return acc
-				.concat("<details><summary>")
-				.concat(blockToString(childBlock.toggle.text))
-				.concat("</summary>")
-				.concat(childBlocksString)
-				.concat("</details>")
-		}
+	// Numbered list item
+	if (block.type == "numbered_list_item") {
+		return prependToLines(markdown, "1.").concat(EOL_MD)
+	}
 
-		if (childBlock.type == "code") {
-			return acc
-				.concat(EOL_MD)
-				.concat("```", childBlock.code.language, EOL_MD)
-				.concat(blockToString(childBlock.code.text))
-				.concat(EOL_MD)
-				.concat("```")
-				.concat(childBlocksString)
-				.concat(EOL_MD)
-		}
+	// Toggle
+	if (block.type == "toggle") {
+		return [
+			EOL_MD,
+			"<details><summary>",
+			blockMarkdown,
+			"</summary>",
+			childMarkdown,
+			"</details>",
+			EOL_MD,
+		].join("")
+	}
 
-		if (childBlock.type == "image") {
-			const imageUrl =
-				childBlock.image.type == "external" ? childBlock.image.external.url : childBlock.image.file.url
+	// Code
+	if (block.type == "code") {
+		return [
+			EOL_MD,
+			`\`\`\` ${block.code.language}${EOL_MD}`,
+			blockMarkdown,
+			EOL_MD,
+			"```",
+			EOL_MD,
+			childMarkdown,
+			EOL_MD,
+		].join("")
+	}
 
-			return acc
-				.concat("![")
-				.concat(blockToString(childBlock.image.caption))
-				.concat("](")
-				.concat(imageUrl)
-				.concat(")")
-				.concat(EOL_MD)
-		}
+	// Image
+	if (block.type == "image") {
+		const imageUrl = block.image.type == "external" ? block.image.external.url : block.image.file.url
+		return `${EOL_MD}![${blockToString(block.image.caption)}](${imageUrl})${EOL_MD}`
+	}
 
-		if (childBlock.type == "audio") {
-			const audioUrl =
-				childBlock.audio.type == "external" ? childBlock.audio.external.url : childBlock.audio.file.url
+	// Audio
+	if (block.type == "audio") {
+		const audioUrl = block.audio.type == "external" ? block.audio.external.url : block.audio.file.url
+		return [EOL_MD, "<audio controls>", `<source src="${audioUrl}" />`, "</audio>", EOL_MD].join("")
+	}
 
-			return acc
-				.concat("<audio controls>")
-				.concat(EOL_MD)
-				.concat(`<source src="${audioUrl}" />`)
-				.concat(EOL_MD)
-				.concat("</audio>")
-				.concat(EOL_MD)
-		}
+	// Video
+	if (block.type == "video" && block.video.type == "external") {
+		return [EOL_MD, block.video.external.url, EOL_MD].join("")
+	}
 
-		if (childBlock.type == "video" && childBlock.video.type == "external") {
-			const videoUrl = childBlock.video.external.url
+	// Embed
+	if (block.type == "embed") {
+		return [EOL_MD, block.embed.url, EOL_MD].join("")
+	}
 
-			return acc.concat(videoUrl).concat(EOL_MD)
-		}
+	// Quote
+	if (block.type == "quote") {
+		return [EOL_MD, prependToLines(markdown, ">", false), EOL_MD].join("")
+	}
 
-		if (childBlock.type == "embed") {
-			return acc.concat(childBlock.embed.url).concat(EOL_MD)
-		}
+	// Bookmark
+	if (block.type == "bookmark") {
+		const bookmarkUrl = block.bookmark.url
+		const bookmarkCaption = blockToString(block.bookmark.caption) || bookmarkUrl
+		return `${EOL_MD}[${bookmarkCaption}](${bookmarkUrl})${EOL_MD}`
+	}
 
-		if (childBlock.type == "quote") {
-			return acc.concat("> ").concat(blockToString(childBlock.quote.text)).concat(EOL_MD)
-		}
+	// Divider
+	if (block.type == "divider") {
+		return `${EOL_MD}---${EOL_MD}`
+	}
 
-		// TODO: Add support for callouts, internal video, andd files
-
-		if (childBlock.type == "bookmark") {
-			const bookmarkUrl = childBlock.bookmark.url
-
-			const bookmarkCaption = blockToString(childBlock.bookmark.caption) || bookmarkUrl
-
-			return acc
-				.concat("[")
-				.concat(bookmarkCaption)
-				.concat("](")
-				.concat(bookmarkUrl)
-				.concat(")")
-				.concat(EOL_MD)
-		}
-
-		if (childBlock.type == "divider") {
-			return acc.concat("---").concat(EOL_MD)
-		}
-
-		if (childBlock.type == "unsupported") {
-			return acc
-				.concat(`<!-- This block is not supported by Notion API yet. -->`)
-				.concat(EOL_MD)
-				.concat(childBlocksString)
-		}
-
-		return acc
-	}, "")
+	// Unsupported types.
+	// TODO: Add support for callouts, internal video, and files
+	return [EOL_MD, `<!-- This block type '${block.type}' is not supported yet. -->`, EOL_MD].join("")
+}


### PR DESCRIPTION
This pull request wholely refactors the `notionBlockToMarkdown` function.

# Description

This code makes a few changes to the existing functionality:

* The `reduce` function could be removed by relying on the recursive nature of the blocks.
* Ensures that most block elements are always separated by two newlines. This is important to prevent them from being interpreted as a single entry, such as with back-to-back blockquotes.
* Allows blockquotes to contain child blocks, such as lists and paragraphs.
* Allows list items to contain child blocks, such as lists and paragraphs.

## Motivation and Context

Originally, my motivation for this was that I needed a blockquote that could contain multiple paragraphs. However, I realized that my approach fixed a few other problems, so I went ahead and did the whole thing.

## Screenshots

I created a [test page](https://landonschropp.notion.site/Example-3c395011b021431cae30e45b876b74c9) in Notion to check the code.

<img width="366" alt="Screen Shot 2022-01-07 at 8 06 15 PM" src="https://user-images.githubusercontent.com/361591/148627551-9f2a4352-400d-4908-9e15-68ba7931b99b.png">

So far, this seems to be parsing well! Here's what the generated markdown looks like:

``` markdown
This is an example paragraph.

[This](http://example.com) `is` **another** _example_ ~~paragraph~~.

---

## Header 1

### Header 2

#### Header 3

---
- [ ]  To do item 1
- [x]  To do item 2
  
  Child of to-do item 2
- [ ]  To do item 3
  
  - [x]  Child 1 of to-do item 3
  - [ ]  Child 2 of to-do item 3

---
* Bulleted item 1
* Bulleted item 2
  
  Child of bulleted item 2
* Bulleted item 3
  
  * Child 1 of bulleted item 3
  * Child 2 of bulleted item 3

---
1. Numbered item 1
1. Numbered item 2
  
  1. Child of numbered item 2
1. Numbered item 3
  
  1. Child 1 of numbered item 3
  1. Child 2 of numbered item 3

---

<details><summary>This is a toggle.</summary>This is the toggle content</details>

---

`` javascript [Backticks edited to display correctly on GitHub]
function() {
  return "code block";
}
``


---

![Bill Murray](https://s3.us-west-2.amazonaws.com/secure.notion-static.com/…1cd0dfe80051a2bc49a5&X-Amz-SignedHeaders=host&x-id=GetObject)

---

> I’m not superstitious, but I am a little stitious.
> 
> —Michael Scott (Steve Carrell),
> 
> _The Office_
---

<audio controls><source src="https://s3.us-west-2.amazonaws.com/secure.notion-static.com/…fe9bf0d1097063f19091&X-Amz-SignedHeaders=host&x-id=GetObject" /></audio>
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Security fix (non-breaking change wich fixes a security issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
