### PR TITLE
Add Caching

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -7,10 +7,10 @@ const YAML = require("yaml")
 const NOTION_NODE_TYPE = "Notion"
 
 exports.sourceNodes = async (
-	{ actions, createContentDigest, createNodeId, reporter },
+	{ actions, createContentDigest, createNodeId, reporter, cache },
 	{ token, databaseId, propsToFrontmatter = true, lowerTitleLevel = true },
 ) => {
-	const pages = await getPages({ token, databaseId }, reporter)
+	const pages = await getPages({ token, databaseId }, reporter, cache)
 
 	pages.forEach((page) => {
 		const title = getNotionPageTitle(page)


### PR DESCRIPTION
# Description

This adds the Gatsby cache to the plugin. When pages are fetched, we first check to see if the page content has been cached. If so, the content is returned directly from the cache.

## Motivation and Context

This dramatically speeds up build times. In my project, my build went from 79 seconds to 13 seconds.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Security fix (non-breaking change which fixes a security issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
