### PR TITLE
Add support for column lists and columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ Untouched contents of whatever Notion API returned.
 
 Markdown contents of the page. Limited by blocks currently supported by Notion API. Unsupported blocks turn into HTML comments specifying that Notion marked this block as non-supported.
 
+Since there's not semantic HTML analog for column lists and columns, these Notion blocks are transformed to `<ColumnList>` and `<Column>` components in the markdown. To customize these components, you can write custom components for these and [include them in your `MDXProvider`](https://www.gatsbyjs.com/docs/mdx/importing-and-using-components#make-components-available-globally-as-shortcodes).
+
 ## Attaching images via "Files" property
 
 If you want to turn images attached through the "Files" property into file nodes that you can use with gatsby-image, you need to attach remote file nodes to the "Files" property. In the example below, the `propsToFrontmatter` is set to **true** and the **_Hero Image_** Files property is used for images:

--- a/src/transformers/notion-block-to-markdown.js
+++ b/src/transformers/notion-block-to-markdown.js
@@ -133,6 +133,33 @@ exports.notionBlockToMarkdown = (block, lowerTitleLevel) => {
 		return `${EOL_MD}---${EOL_MD}`
 	}
 
+	// Column List
+	if (block.type == "column_list") {
+		return [
+			EOL_MD,
+			"<ColumnList>",
+			EOL_MD,
+			markdown,
+			EOL_MD,
+			"</ColumnList>",
+			EOL_MD
+		].join("")
+	}
+
+	// Column
+	if (block.type == "column") {
+		return [
+			"<Column>",
+			EOL_MD,
+			EOL_MD,
+			markdown,
+			EOL_MD,
+			EOL_MD,
+			"</Column>",
+			EOL_MD
+		].join("")
+	}
+
 	// Unsupported types.
 	// TODO: Add support for callouts, internal video, and files
 	return [EOL_MD, `<!-- This block type '${block.type}' is not supported yet. -->`, EOL_MD].join("")


### PR DESCRIPTION
- Add support for column lists and columns
- Add documentation for column lists and columns

# Description

I've included support for Notion's column list and column blocks.

## Motivation and Context

In my project, I needed a way to render Notion's columns. Prior to this change, this was not possible using gatsby-source-notion-api.

## Screenshots

<img width="760" alt="Screen Shot 2022-07-24 at 4 26 47 PM" src="https://user-images.githubusercontent.com/361591/180666514-8a08c551-9e8a-44be-848a-95c1640db693.png">

<!-- If appropriate -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Security fix (non-breaking change wich fixes a security issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
