### PR TITLE
:sparkles: Add support for multiple databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Integration token.
 The identifier of the database you want to get pages from. The integration identified by provided
 token must have access to the database with given id.
 
+`nodeTypeName` [string][optional]
+
+Defines the name of the entity to be queried. For instance, a `nodeTypeName` of value `notionTeamMember` will allow creating queries named `allNotionTeamMember(...)`. Defaults to the string `"Notion"`.
+
+This is particularly useful in case you want having multiple Notion databases.
+
 `propsToFrontmatter` [boolean][defaults to **true**]
 
 Put Notion page props to Markdown frontmatter. If you set this to **false**, you will need to query `notion` to get page props.
@@ -253,12 +259,41 @@ exports.onCreateNode = async ({ node, actions: { createNode }, createNodeId, get
 
 - Due to the fact that Notion API only appeared recently, and it is still in beta, some blocks are
   marked "unsupported". Among others, images cannot be fetched for now
-- Currently, `gatsby-source-notion-api` can only work with one provided database. In further
-  releases, all databases reachable by the Integration will be available for querying
+- ~~Currently, `gatsby-source-notion-api` can only work with one provided database. In further
+  releases, all databases reachable by the Integration will be available for querying~~ Querying multiple databases is now supported! Please read the doc below.
 - ~~Nested blocks are currently skipped. E.g. if a list item has a nested sublist, it's contents will
   be omitted. This will be fixed in the nearest releases~~ Nested blocks are supported as of `0.4.0`!
 - ~~Only raw content is available. Raw meaning whatever Notion returns. Further releases will aim at
   providing a more convenient data format apart from the raw one~~ `0.3.0` features support for **archived**, **createdAt**, **updatedAt**, **properties** and **title**.
+
+## Querying multiple databases
+
+In order to query multiple databases, you can add multiple `gatsby-source-notion-api` in your project’s `gatsby-config.js` **and** set different `nodeTypeName` values. For instance:
+
+```javascript
+  plugins: [
+    {
+      resolve: `gatsby-source-notion-api`,
+      options: {
+        token: `$INTEGRATION_TOKEN`,
+        databaseId: `$DATABASE_ID`,
+        nodeTypeName: "notionTeamMember",
+        propsToFrontmatter: true,
+        lowerTitleLevel: true,
+      },
+    },
+    {
+      resolve: `gatsby-source-notion-api`,
+      options: {
+        token: `$INTEGRATION_TOKEN`,
+        databaseId: `$DATABASE_ID`,
+        nodeTypeName: "notionTask",
+        propsToFrontmatter: true,
+        lowerTitleLevel: true,
+      },
+    },
+  ],
+```
 
 ## 🎉 You did it
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -4,17 +4,18 @@ const { getNotionPageProperties } = require("./src/transformers/get-page-propert
 const { getNotionPageTitle } = require("./src/transformers/get-page-title")
 const YAML = require("yaml")
 
-const NOTION_NODE_TYPE = "Notion"
+const DEFAULT_NOTION_NODE_TYPE = "Notion"
 
 exports.sourceNodes = async (
 	{ actions, createContentDigest, createNodeId, reporter, cache },
-	{ token, databaseId, propsToFrontmatter = true, lowerTitleLevel = true },
+	{ token, databaseId, nodeTypeName = null, propsToFrontmatter = true, lowerTitleLevel = true },
 ) => {
 	const pages = await getPages({ token, databaseId }, reporter, cache)
 
 	pages.forEach((page) => {
 		const title = getNotionPageTitle(page)
 		const properties = getNotionPageProperties(page)
+		const notionNodeType = nodeTypeName ?? DEFAULT_NOTION_NODE_TYPE;
 		let markdown = notionBlockToMarkdown(page, lowerTitleLevel)
 
 		if (propsToFrontmatter) {
@@ -30,7 +31,7 @@ exports.sourceNodes = async (
 		}
 
 		actions.createNode({
-			id: createNodeId(`${NOTION_NODE_TYPE}-${page.id}`),
+			id: createNodeId(`${notionNodeType}-${page.id}`),
 			title,
 			properties,
 			archived: page.archived,
@@ -42,7 +43,7 @@ exports.sourceNodes = async (
 			parent: null,
 			children: [],
 			internal: {
-				type: NOTION_NODE_TYPE,
+				type: notionNodeType,
 				mediaType: "text/markdown",
 				content: markdown,
 				contentDigest: createContentDigest(page),


### PR DESCRIPTION
# Description

This PR adds support for querying multiple databases by adding a new `nodeTypeName` property.

In order to query multiple databases, you can add multiple `gatsby-source-notion-api` in your project’s `gatsby-config.js` **and** set different `nodeTypeName` values. For instance:

```javascript
  plugins: [
    {
      resolve: `gatsby-source-notion-api`,
      options: {
        token: `$INTEGRATION_TOKEN`,
        databaseId: `$DATABASE_ID`,
        nodeTypeName: "notionTeamMember",
        propsToFrontmatter: true,
        lowerTitleLevel: true,
      },
    },
    {
      resolve: `gatsby-source-notion-api`,
      options: {
        token: `$INTEGRATION_TOKEN`,
        databaseId: `$DATABASE_ID`,
        nodeTypeName: "notionTask",
        propsToFrontmatter: true,
        lowerTitleLevel: true,
      },
    },
  ],
```

`nodeTypeName` is optional and defaults to `"Notion"`, so the change is non-breaking.

## Motivation and Context

https://github.com/orlowdev/gatsby-source-notion-api/issues/3

## Screenshots

<!-- If appropriate -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Security fix (non-breaking change wich fixes a security issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
